### PR TITLE
Use #!/bin/bash instead of #!/bin/sh due to use of array variables

### DIFF
--- a/git-rebase-all
+++ b/git-rebase-all
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 USAGE='<new-upstream> <root>'
 OPTIONS_KEEPDASHDASH=


### PR DESCRIPTION
Use #!/bin/bash instead of #!/bin/sh due to use of array variables

Array variables are not available in Bourne/POSIX shells, so the
script doesn't work if /bin/sh is not symlinked to bash.
The variables are branches_list and new_commit_list.