### PR TITLE
Fix branch list including the upstream and any detached head.

### DIFF
--- a/git-rebase-all
+++ b/git-rebase-all
@@ -45,7 +45,7 @@ if [ $# -eq 2 ]; then
   root=$2
 
   # Fetch all the branches that contain the root of the subtree
-  branches=$(git branch --contains $root | cut -c 3-)
+  branches=$(git for-each-ref --contains $root --no-merged $new_upstream --format='%(refname:strip=2)' refs/heads/)
 
   echo rebasing $branches onto $new_upstream
 


### PR DESCRIPTION
If the upstream is a branch instead of a remote, it would be included
in the list of branches to rebase, likewise if a branch had already
been merged. Exclude those using --no-merged.
If no branch is checked out, and the detached head is contained by
$root, git branch will add it to the list, so filter it out.
